### PR TITLE
Don't mark untyped changes as high priority

### DIFF
--- a/Change.cs
+++ b/Change.cs
@@ -38,7 +38,7 @@ namespace KerbalChangelog
 						type = ChangeType.Change;
 						break;
 					case "D":
-						type = ChangeType.Depreciate;
+						type = ChangeType.Deprecate;
 						break;
 					case "R":
 						type = ChangeType.Remove;
@@ -51,6 +51,9 @@ namespace KerbalChangelog
 						break;
 					case "H":
 						type = ChangeType.HighPriority;
+						break;
+					case "P":
+						type = ChangeType.Performance;
 						break;
 					default:
 						type = ChangeType.None;

--- a/ChangeTypes.cs
+++ b/ChangeTypes.cs
@@ -3,13 +3,13 @@ namespace KerbalChangelog
 {
 	public enum ChangeType
 	{
+		None,
 		HighPriority,
 		Add,
 		Change,
 		Depreciate,
 		Remove,
 		Fix,
-		Security,
-		None
+		Security
 	}
 }

--- a/ChangeTypes.cs
+++ b/ChangeTypes.cs
@@ -7,9 +7,10 @@ namespace KerbalChangelog
 		HighPriority,
 		Add,
 		Change,
-		Depreciate,
+		Deprecate,
 		Remove,
 		Fix,
-		Security
+		Security,
+		Performance,
 	}
 }

--- a/Changelog.cs
+++ b/Changelog.cs
@@ -25,7 +25,7 @@ namespace KerbalChangelog
 				{
 					return changeSets[0].version;
 				}
-				catch (Exception e)
+				catch (Exception)
 				{
 					Debug.Log("[KCL] No changesets exist.");
 					return null;


### PR DESCRIPTION
## Problems

- If you use the older `change = ` syntax, the change will incorrectly be labelled as high priority
- One of the change types is `Depreciate`, [which is a finance term meaning to lose monetary value over time](https://stackoverflow.com/a/9208164/2422988)

## Causes

The `Change.type` variable will default to `0` if not set, which corresponds to the first value in the `enum`, which is currently `HighPriority`. Therefore all changes without a `type` specifier are being set as high priority.

## Motivation

A somewhat common type of software change is the performance improvement. Currently the closest available option for such a change is `Fix`, but that usually indicates that something was _broken_ rather than just slow. If `Security` is distinct enough for its own type, performance fixes probably are, too.

## Changes

- Now the `enum` is rearranged so that `None` is first and will be the default
- Now `Depreciate` is changed to `Deprecate`
- Now there's a `Performance` change type

Tagging @BenjaminCronin to make sure GitHub sends a notification.